### PR TITLE
Reexport the buildtoolchain feature from libdragon-sys

### DIFF
--- a/libdragon/Cargo.toml
+++ b/libdragon/Cargo.toml
@@ -20,3 +20,6 @@ embedded-io = "0.6.1"
 paste = "1.0"
 function_name = "0.3"
 bitflags = "2.5.0"
+
+[features]
+buildtoolchain = ["libdragon-sys/buildtoolchain"]


### PR DESCRIPTION
Reexporting the buildtoolchain feature from libdragon-sys in the libdragon crate.