### PR TITLE
Add support for converting .glb to .model64 when building

### DIFF
--- a/libdragon-build/src/Justfile.inc
+++ b/libdragon-build/src/Justfile.inc
@@ -31,6 +31,16 @@ lb-build-assets:
     # compile assets
     # TODO need a way to specify custom arguments, perhaps in the project's build.rs script
     if [ -d assets ]; then
+
+        # MODEL64
+        for model in `find assets -name "*.glb"` ; do
+            fn=$(basename "$model" .glb)
+            if [ "$model" -nt "$fs/$fn.model64" -o ! -f "$fs/$fn.model64" ]; then
+                echo Compiling $model
+                "$DEP_LIBDRAGON_SYS_N64_TOOLDIR"/mkmodel -o "$fs" "$model"
+            fi
+        done
+
         # MKSPRITE
         for sprite in `find assets -name "*.png"` ; do 
             fn=$(basename "$sprite" .png)


### PR DESCRIPTION
I have noticed that the Just file handle converting a lot of assets into format compatible with libdragon except for `.glb` to `.model64`.

I've added the supplied rule to my own Rust project and I have seen that it works without issue. So I guess it should be part of the main Justfile.

I can provide an example that use Model64 as an example if necessary.